### PR TITLE
fix: The Ghost Button of the theme is not visible

### DIFF
--- a/src/previews/components/button/button.tsx
+++ b/src/previews/components/button/button.tsx
@@ -1,16 +1,28 @@
-import { Button, Space } from 'antd';
+import { Button, Flex, Space } from 'antd';
 import React from 'react';
 import type { ComponentDemo } from '../../../interface';
 
 const Demo = () => (
-  <Space>
-    <Button type="primary">Primary Button</Button>
-    <Button>Default Button</Button>
-    <Button type="dashed">Dashed Button</Button> <br />
-    <Button type="text">Text Button</Button>
-    <Button ghost>Ghost Button</Button>
-    <Button type="link">Link Button</Button>
-  </Space>
+  <>
+    <Space wrap>
+      <Button type="primary">Primary Button</Button>
+      <Button>Default Button</Button>
+      <Button type="dashed">Dashed Button</Button> <br />
+      <Button type="text">Text Button</Button>
+      <Button type="link">Link Button</Button>
+    </Space>
+    <Flex
+      justify="center"
+      align="center"
+      style={{
+        backgroundColor: 'rgb(190,200,200)',
+        height: 50,
+        marginTop: 16,
+      }}
+    >
+      <Button ghost>Ghost Button</Button>
+    </Flex>
+  </>
 );
 
 const componentDemo: ComponentDemo = {


### PR DESCRIPTION
关联 issue  close https://github.com/ant-design/ant-design/issues/53606 
给主题中的 Ghost Btton 添加背景色
修改后效果：
<img width="2744" height="976" alt="image" src="https://github.com/user-attachments/assets/b4fab4a0-7225-43c4-999d-8e9558db68bc" />
<img width="2730" height="1046" alt="image" src="https://github.com/user-attachments/assets/5d79a844-2a55-4c82-96f8-04b0ee0d9bfb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式**
  * 将幽灵按钮从原有按钮组中分离，单独放置在带有背景色和居中样式的容器中，提升视觉效果和布局清晰度。其他按钮保持原有分组与换行展示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->