### PR TITLE
feat: Modify the theme editor theme color selection position

### DIFF
--- a/src/ThemeEditor.tsx
+++ b/src/ThemeEditor.tsx
@@ -1,6 +1,6 @@
 import type { DerivativeFunc } from '@ant-design/cssinjs';
 import { CaretDownOutlined } from '@ant-design/icons';
-import { Button, Dropdown, message, Segmented, Tag } from 'antd';
+import { Button, Dropdown, message, Segmented, Space, Tag } from 'antd';
 import classNames from 'classnames';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import type { ReactNode } from 'react';
@@ -16,11 +16,13 @@ import type { EditorModalProps } from './editor-modal';
 import EditorModal from './editor-modal';
 import GlobalTokenEditor from './GlobalTokenEditor';
 import useControlledTheme from './hooks/useControlledTheme';
+import { DarkTheme, Light } from './icons';
 import type { Theme } from './interface';
 import type { Locale } from './locale';
 import { LocaleContext, zhCN } from './locale';
 import { HIGHLIGHT_COLOR } from './utils/constants';
 import makeStyle from './utils/makeStyle';
+import { isLeftChecked, switchAlgorithm } from './utils/themeAlgorithmUtils';
 
 const useStyle = makeStyle('ThemeEditor', (token) => ({
   [token.componentCls]: {
@@ -216,17 +218,34 @@ const ThemeEditor = forwardRef<ThemeEditorRef, ThemeEditorProps>(
                   </Tag>
                 </Dropdown>
               )}
-              {advanced && (
+              <Space size="middle">
+                {advanced && (
+                  <Segmented
+                    value={mode}
+                    options={[
+                      { label: locale.globalToken, value: 'global' },
+                      { label: locale.componentToken, value: 'component' },
+                    ]}
+                    onChange={(v) => setMode(v as ThemeEditorMode)}
+                    style={{ marginLeft: 24 }}
+                  />
+                )}
+
                 <Segmented
-                  value={mode}
                   options={[
-                    { label: locale.globalToken, value: 'global' },
-                    { label: locale.componentToken, value: 'component' },
+                    {
+                      icon: <Light style={{ fontSize: 16 }} />,
+                      value: 'light',
+                    },
+                    {
+                      icon: <DarkTheme style={{ fontSize: 16 }} />,
+                      value: 'dark',
+                    },
                   ]}
-                  onChange={(v) => setMode(v as ThemeEditorMode)}
-                  style={{ marginLeft: 24 }}
+                  onChange={switchAlgorithm('dark', theme)}
+                  value={isLeftChecked('dark', theme) ? 'light' : 'dark'}
                 />
-              )}
+              </Space>
               <div className={`${prefixCls}-header-actions`}>
                 <span
                   className={`${prefixCls}-header-actions-diff`}

--- a/src/token-panel-pro/TokenContent.tsx
+++ b/src/token-panel-pro/TokenContent.tsx
@@ -19,15 +19,14 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useDebouncyFn } from 'use-debouncy';
 import ColorPicker from '../ColorPicker';
 import { useAdvanced } from '../context';
-import type { ThemeCode } from '../hooks/useControlledTheme';
-import { themeMap } from '../hooks/useControlledTheme';
-import { CompactTheme, DarkTheme, Light } from '../icons';
+import { CompactTheme } from '../icons';
 import type { SelectedToken } from '../interface';
 import { useLocale } from '../locale';
 import type { TokenCategory, TokenGroup } from '../meta/interface';
 import { HIGHLIGHT_COLOR } from '../utils/constants';
 import getDesignToken from '../utils/getDesignToken';
 import makeStyle from '../utils/makeStyle';
+import { isLeftChecked, switchAlgorithm } from '../utils/themeAlgorithmUtils';
 import InputNumberPlus from './InputNumberPlus';
 import ResetTokenButton from './ResetTokenButton';
 import TokenPreview from './TokenPreview';
@@ -683,35 +682,6 @@ const TokenContent: FC<ColorTokenContentProps> = ({
   const advanced = useAdvanced();
   const { token } = antdTheme.useToken();
 
-  const switchAlgorithm = (themeStr: 'dark' | 'compact') => () => {
-    let newAlgorithm = theme.config.algorithm;
-    if (!newAlgorithm) {
-      newAlgorithm = themeMap[themeStr];
-    } else if (Array.isArray(newAlgorithm)) {
-      newAlgorithm = newAlgorithm.includes(themeMap[themeStr])
-        ? newAlgorithm.filter((item) => item !== themeMap[themeStr])
-        : [...newAlgorithm, themeMap[themeStr]];
-    } else {
-      newAlgorithm =
-        newAlgorithm === themeMap[themeStr]
-          ? undefined
-          : [newAlgorithm, themeMap[themeStr]];
-    }
-    theme.onThemeChange?.({ ...theme.config, algorithm: newAlgorithm }, [
-      'config',
-      'algorithm',
-    ]);
-  };
-
-  const isLeftChecked = (str: ThemeCode) => {
-    if (!theme.config.algorithm) {
-      return true;
-    }
-    return Array.isArray(theme.config.algorithm)
-      ? !theme.config.algorithm.includes(themeMap[str])
-      : theme.config.algorithm !== themeMap[str];
-  };
-
   return (
     <div className={classNames(hashId, 'token-panel-pro-color')} id={id}>
       <div className="token-panel-pro-color-seeds">
@@ -719,17 +689,6 @@ const TokenContent: FC<ColorTokenContentProps> = ({
           <span style={{ marginRight: 12 }}>
             {locale._lang === 'zh-CN' ? category.name : category.nameEn}
           </span>
-          {category.nameEn === 'Color' && (
-            <Segmented
-              options={[
-                { icon: <Light style={{ fontSize: 16 }} />, value: 'light' },
-                { icon: <DarkTheme style={{ fontSize: 16 }} />, value: 'dark' },
-              ]}
-              onChange={switchAlgorithm('dark')}
-              value={isLeftChecked('dark') ? 'light' : 'dark'}
-              style={{ marginLeft: 'auto' }}
-            />
-          )}
           {category.nameEn === 'Size' && (
             <Segmented
               options={[
@@ -744,8 +703,8 @@ const TokenContent: FC<ColorTokenContentProps> = ({
                   value: 'compact',
                 },
               ]}
-              onChange={switchAlgorithm('compact')}
-              value={isLeftChecked('compact') ? 'normal' : 'compact'}
+              onChange={switchAlgorithm('compact', theme)}
+              value={isLeftChecked('compact', theme) ? 'normal' : 'compact'}
               style={{ marginLeft: 'auto' }}
             />
           )}

--- a/src/utils/themeAlgorithmUtils.ts
+++ b/src/utils/themeAlgorithmUtils.ts
@@ -1,0 +1,33 @@
+import type { ThemeCode } from '../hooks/useControlledTheme';
+import { themeMap } from '../hooks/useControlledTheme';
+import type { MutableTheme } from '../interface';
+
+export const isLeftChecked = (str: ThemeCode, theme: MutableTheme) => {
+  if (!theme.config.algorithm) {
+    return true;
+  }
+  return Array.isArray(theme.config.algorithm)
+    ? !theme.config.algorithm.includes(themeMap[str])
+    : theme.config.algorithm !== themeMap[str];
+};
+
+export const switchAlgorithm =
+  (themeStr: 'dark' | 'compact', theme: MutableTheme) => () => {
+    let newAlgorithm = theme.config.algorithm;
+    if (!newAlgorithm) {
+      newAlgorithm = themeMap[themeStr];
+    } else if (Array.isArray(newAlgorithm)) {
+      newAlgorithm = newAlgorithm.includes(themeMap[themeStr])
+        ? newAlgorithm.filter((item) => item !== themeMap[themeStr])
+        : [...newAlgorithm, themeMap[themeStr]];
+    } else {
+      newAlgorithm =
+        newAlgorithm === themeMap[themeStr]
+          ? undefined
+          : [newAlgorithm, themeMap[themeStr]];
+    }
+    theme.onThemeChange?.({ ...theme.config, algorithm: newAlgorithm }, [
+      'config',
+      'algorithm',
+    ]);
+  };


### PR DESCRIPTION
 close https://github.com/ant-design/ant-design/issues/53348

修改主题编辑器的主题切换按钮位置

<img width="2736" height="1150" alt="image" src="https://github.com/user-attachments/assets/69a3943a-8e91-484a-a368-c3ff33e33db4" />
<img width="2740" height="1288" alt="image" src="https://github.com/user-attachments/assets/ed8938fd-2c56-4c19-b335-4a7130cf2b30" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 在主题编辑器头部新增了明暗模式切换控件，可直接切换浅色和深色主题。

* **重构**
  * 优化了主题算法切换逻辑，将相关功能提取为通用工具函数，提升了代码复用性。
  * Token 面板移除了明暗模式切换，仅保留紧凑模式切换，逻辑更清晰。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->