### PR TITLE
fix: use numeric input for lineHeight tokens

### DIFF
--- a/src/token-panel-pro/TokenContent.tsx
+++ b/src/token-panel-pro/TokenContent.tsx
@@ -400,7 +400,9 @@ const SeedTokenPreview: FC<React.PropsWithChildren<SeedTokenProps>> = (
           <InputNumber<number>
             style={{ minWidth: 200 }}
             value={tokenValue}
-            onChange={(newValue) => handleChange(newValue ?? 0)}
+            step={0.01}
+            min={1}
+            onChange={(newValue) => handleChange(newValue ?? 1)}
           />
         </div>
       )}

--- a/src/token-panel-pro/TokenContent.tsx
+++ b/src/token-panel-pro/TokenContent.tsx
@@ -8,6 +8,7 @@ import {
   Switch,
   theme as antdTheme,
   Tooltip,
+  InputNumber,
 } from 'antd';
 import type { MutableTheme } from 'antd-token-previewer';
 import type { ThemeConfig } from 'antd/es/config-provider/context';
@@ -385,14 +386,21 @@ const SeedTokenPreview: FC<React.PropsWithChildren<SeedTokenProps>> = (
           max={seedRange[tokenGroup].max}
         />
       )}
-      {['boxShadow', 'lineHeight'].some((prefix) =>
-        tokenName.startsWith(prefix),
-      ) && (
+      {tokenName.startsWith('boxShadow') && (
         <div>
           <Input.TextArea
             value={tokenValue}
             onChange={({ target: { value } }) => handleChange(value)}
             style={{ width: 200 }}
+          />
+        </div>
+      )}
+      {tokenName.startsWith('lineHeight') && (
+        <div>
+          <InputNumber<number>
+            style={{ minWidth: 200 }}
+            value={tokenValue}
+            onChange={(newValue) => handleChange(newValue ?? 0)}
           />
         </div>
       )}


### PR DESCRIPTION
用[主题编辑器]修改行高之后，导出主题配置theme.json，将它放到`<ConfigProvider>`后会出现TS报错："token.lineHeight" 的类型不兼容。类型“string”不可与类型“number”进行比较。
<img width="1714" height="640" alt="image" src="https://github.com/user-attachments/assets/1434a66f-370f-4b8d-a134-f261f83d0a65" />

产生TS报错的原因是theme.json里lineHeight为string类型与ThemeConfig类型要求的number不一致。

当前PR将`lineHeight*` 字段改为InputNumber，确保导出配置时是number类型。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * 改进了令牌输入的渲染逻辑：行高令牌改为数字输入，支持步进 0.01、最小值 1，并在空值时默认为 1，以提升准确性和易用性
  * 保持阴影类令牌的文本区域输入方式不变

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->