### PR TITLE
fix: sync dashboard banner color

### DIFF
--- a/src/previews/pages/dashboard/index.tsx
+++ b/src/previews/pages/dashboard/index.tsx
@@ -30,7 +30,6 @@ import makeStyle from '../../../utils/makeStyle';
 const useStyle = makeStyle('AppDemoDashboard', (token) => ({
   [token.componentCls]: {
     [`&-banner${token.rootCls}-card`]: {
-      backgroundColor: token.colorPrimary,
       color: token.colorTextLightSolid,
       '&::before': {
         content: '""',
@@ -231,7 +230,10 @@ const Dashboard: FC = () => {
         style={{ width: '100%' }}
         size={token.marginLG}
       >
-        <Card className={`${prefixCls}-banner`}>
+        <Card
+          className={`${prefixCls}-banner`}
+          style={{ backgroundColor: token.colorPrimary }}
+        >
           <div style={{ display: 'flex', alignItems: 'flex-start' }}>
             <div className={`${prefixCls}-banner-title`}>
               Hi，欢迎使用应用 Paas 平台！


### PR DESCRIPTION
## 问题说明

修复 Theme Editor 中修改 `colorPrimary` 后，Dashboard 预览页 banner 背景色没有实时更新的问题。

官网地址：https://ant.design/theme-editor-cn

## 复现步骤

1. 打开 https://ant.design/theme-editor-cn
2. 在 Theme Editor 中修改主色，也就是 `colorPrimary`
3. 查看 Dashboard 预览页顶部的 banner card
4. 此时 banner 背景色没有立即更新
5. 切换预览样式，或者触发其他刷新后，banner 背景色才会更新

## 期望表现

修改 `colorPrimary` 后，Dashboard banner 背景色应该立即同步更新。

## 实际表现

`token.colorPrimary` 本身已经发生变化，但当前通过 css-in-js 生成的 banner 背景样式没有立即刷新，导致页面上看到的背景色仍然是旧值。

## 修改内容

仅将 Dashboard banner 的 `backgroundColor` 从 `makeStyle` 中移动到 `Card` 的 inline style：

```tsx
<Card
  className={`${prefixCls}-banner`}
  style={{ backgroundColor: token.colorPrimary }}
>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化了仪表盘 banner 组件的样式应用机制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->